### PR TITLE
Satisfactory: 'trap_selection_override' option was unable to be used 

### DIFF
--- a/worlds/satisfactory/Items.py
+++ b/worlds/satisfactory/Items.py
@@ -832,7 +832,7 @@ class Items:
 
     def get_filler_item_name(self, random: Random, options: SatisfactoryOptions) -> str:
         trap_chance: int = options.trap_chance.value
-        enabled_traps: List[str] = options.trap_selection_override.value
+        enabled_traps: List[str] = list(options.trap_selection_override.value)
 
         if enabled_traps and random.random() < (trap_chance / 100):
             return random.choice(enabled_traps)


### PR DESCRIPTION
## What is this fixing or adding?
'trap_selection_override' option for satisfactory

## How was this tested?
generate.py - doesn't throw an error