### PR TITLE
Satisfactory: Fix the player settings link.

### DIFF
--- a/worlds/satisfactory/docs/en_Satisfactory.md
+++ b/worlds/satisfactory/docs/en_Satisfactory.md
@@ -4,7 +4,7 @@
 
 ## Where is the settings page?
 
-The [player settings page for this game](../player-settings)
+The [player settings page for this game](../player-options)
 contains all the options you need to configure and export a config file.
 
 > ⚠ Pre-Release Note: The above link does not work because it would go to the live Archipelago site.


### PR DESCRIPTION
I host a copy of the site on my own server for my friend group, so this link actually **would** work for us (despite the pre-release note below) if it were pointing here instead.